### PR TITLE
added github action

### DIFF
--- a/.docker/Dockerfile.php55
+++ b/.docker/Dockerfile.php55
@@ -1,0 +1,15 @@
+FROM php:5.5-cli
+
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get -y update && \
+        apt-get install -y build-essential libpng-dev libgif-dev
+COPY . /tmp/ext
+
+WORKDIR /tmp/ext/src
+
+#RUN make clean && phpize --clean
+RUN phpize && ./configure && make
+
+CMD make test NO_INTERACTION=1 TESTS=--show-diff
+

--- a/.docker/Dockerfile.php72
+++ b/.docker/Dockerfile.php72
@@ -1,0 +1,15 @@
+FROM php:7.2-cli
+
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get -y update && \
+        apt-get install -y build-essential libpng-dev libgif-dev
+COPY . /tmp/ext
+
+WORKDIR /tmp/ext/src
+
+#RUN make clean && phpize --clean
+RUN phpize && ./configure && make
+
+CMD make test NO_INTERACTION=1 TESTS=--show-diff
+

--- a/.github/workflows/php5.yml
+++ b/.github/workflows/php5.yml
@@ -1,0 +1,14 @@
+name: php55
+
+on: [workflow_dispatch, push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup docker container
+      run: docker build -t swfed -f ./.docker/Dockerfile.php55 .
+    - name: run test
+      run: docker run --rm swfed
+

--- a/.github/workflows/php7.yml
+++ b/.github/workflows/php7.yml
@@ -1,0 +1,14 @@
+name: php72
+
+on: [workflow_dispatch, push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup docker container
+      run: docker build -t swfed -f ./.docker/Dockerfile.php72 .
+    - name: run test
+      run: docker run --rm swfed
+


### PR DESCRIPTION
DockerでCI回せるようにしてgithub actionsでPRと同時に動くようにしてみました。

* https://github.com/withgod/swfed/actions

php72でfailしてるんですが、これはそもそもテストがFailするみたいです...

https://github.com/withgod/swfed/runs/1488797876?check_suite_focus=true#step:4:48

手元で ubuntu/mac環境でも出るの確認しました。
```
ubuntu@primary:~/tmp/swfed/src$ cat ./tests/bitmap003.log

---- EXPECTED OUTPUT
460b54df088502aed74b8042c09fcfef
===DONE===
---- ACTUAL OUTPUT
libpng warning: iCCP: known incorrect sRGB profile
460b54df088502aed74b8042c09fcfef
===DONE===
---- FAILED
```
動作は問題無いけど警告が出ちゃうみたいですね…

png profile直せば出なくなる見たいですが、本ブランチ対象では無いなーと言う事でここでは直してません。